### PR TITLE
Bugfix recursive rule-naming

### DIFF
--- a/scss.js
+++ b/scss.js
@@ -2,7 +2,7 @@ const { rules } = require('./index');
 
 module.exports = {
   rules: Object.entries(rules).reduce(
-    (rules, k, v) => Object.assign(rules, { [`scss/${k}`]: v }),
-    { ...rules }
+    (rules, [k, v]) => Object.assign({ [`scss/${k}`]: v }, rules),
+    rules
   ),
 };

--- a/scss.js
+++ b/scss.js
@@ -2,7 +2,7 @@ const { rules } = require('./index');
 
 module.exports = {
   rules: Object.entries(rules).reduce(
-    (rules, [k, v]) => Object.assign(rules, { [`scss/${k}`]: v }),
-    rules
+    (rules, k, v) => Object.assign(rules, { [`scss/${k}`]: v }),
+    { ...rules }
   ),
 };


### PR DESCRIPTION
Fixes #3

### Problem/Bug
`Object.assign` changes the imported `rules` in-place. Therefore, on each run, `rules` already has the additonal `scss/` variants.

So it makes `scss/` variants for each of these, resulting in recursively added doubles and more. See example:

#### Run 1:
```
{
  "some-rule": null,
}
```
becomes
```
{
  "some-rule": null,
  "scss/some-rule": null,
}
```

#### Run 2:
```
{
  "some-rule": null,
  "scss/some-rule": null,
}
```
becomes
```
{
  "some-rule": null,
  "scss/some-rule": null, // <------- this. ---------,
  "scss/some-rule": null, // --- This overwrites ---`
  "scss/scss/some-rule": null,
}
```

#### Run 3:
```
{
  "some-rule": null,
  "scss/some-rule": null,
  "scss/scss/some-rule": null,
}
```
becomes
```
{
  "some-rule": null,
  "scss/some-rule": null, // <------- this. ---------,
  "scss/some-rule": null, // --- This overwrites ---`
  "scss/scss/some-rule": null, // <------- this. ---------,
  "scss/scss/some-rule": null, // --- This overwrites ---`
  "scss/scss/scss/some-rule": null,
}
```

**_...etc..._**