### PR TITLE
Allow Tailwind at-rules before @import (no-invalid-position-at-import-rule)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,35 @@
 module.exports = {
   rules: {
     'import-notation': null,
+    // Tailwind at-rules (e.g. `@config`, `@theme`, `@source`) may legitimately
+    // appear before `@import`, which would otherwise be flagged as an invalid
+    // import position. Ignore them so the "Tailwind without Preflight" pattern
+    // (`@config` followed by `@import "tailwindcss/*"`) lints cleanly.
+    // See https://github.com/zhilidali/stylelint-config-tailwindcss/issues/13
+    'no-invalid-position-at-import-rule': [
+      true,
+      {
+        ignoreAtRules: [
+          /** tailwindcss v4 */
+          'theme',
+          'source',
+          'utility',
+          'variant',
+          'custom-variant',
+          'plugin',
+          'reference',
+          /** tailwindcss v3 */
+          'tailwind',
+          'apply',
+          'layer',
+          'config',
+          /** tailwindcss v1, v2 */
+          'variants',
+          'responsive',
+          'screen',
+        ],
+      },
+    ],
     'at-rule-no-unknown': [
       true,
       {


### PR DESCRIPTION
### Problem
Tailwind's ["without Preflight"](https://tailwindcss.com/docs/preflight#disabling-preflight) setup, and Tailwind v4 generally, place `@config` and directives like `@source`/`@theme` **before** the `@import "tailwindcss/*"` layer imports. stylelint's `no-invalid-position-at-import-rule` (active via `stylelint-config-standard`) flags those `@import`s as invalidly positioned, so this config doesn't fully cover the Tailwind import pattern.

This is the issue reported in #13.

### Change
Configure `no-invalid-position-at-import-rule` to `ignoreAtRules` the same set of Tailwind at-rules already allow-listed for `at-rule-no-unknown` (including `config`, `source`, `variant`, `theme`, `plugin`, …). With this, the common pattern lints cleanly:

```css
@config "../tailwind.config.js";

@import "tailwindcss/theme.css" layer(theme);
@import "tailwindcss/utilities.css" layer(utilities);
```

Fixes #13